### PR TITLE
Fix incorrect PostCSS Tailwind plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['tailwindcss'],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- fix plugin name in PostCSS configuration files

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module 'next' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684548c424d48327bca036fca5b5011a